### PR TITLE
Check if restaurant is open

### DIFF
--- a/popup.js
+++ b/popup.js
@@ -48,7 +48,7 @@ const addTrackedRestaurant = async () => {
       throw `You're already tracking ${restaurant_details.name} availability`;
     } else {
       if (!restaurant_details.open) {
-        alert(`${restaurant_details.name} is closed`);
+        throw `${restaurant_details.name} is closed`;
       } else {
         if (!restaurant_details.online) {
           restaurants.push(restaurant_details);


### PR DESCRIPTION
Up until now, we checked only if the restaurant is online. We found out that even though the restaurant is closed, the online parameter is set to true. This PR makes sure that the restaurant is open, before checking the online parameter.